### PR TITLE
Add vcpkg, nlohmann-json library and switch Stats plugin over

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,5 +6,6 @@ Debug
 Release
 *.vcxproj.user
 *.log
+project/vcpkg_installed
 
 !misc/acctpath_patch/bin/*.cfg

--- a/plugins/stats_plugin/Main.cpp
+++ b/plugins/stats_plugin/Main.cpp
@@ -16,7 +16,7 @@ void LoadSettings() {
     GetCurrentDirectory(sizeof(szCurDir), szCurDir);
     std::string configFile =
         std::string(szCurDir) + "\\flhook_plugins\\stats.cfg";
-    jsonFileName = IniGetS(configFile, "General", "jsonFileName", "");
+    jsonFileName = IniGetS(configFile, "General", "jsonFileName", "EXPORTS\\stats.json");
 
     HkLoadStringDLLs();
 
@@ -44,6 +44,7 @@ void LoadSettings() {
     }
 }
 
+// This removes double quotes from player names. This causes invalid json.
 std::string encode(std::string data) {
     std::string scEncoded;
     scEncoded.reserve(data.size());
@@ -56,50 +57,49 @@ std::string encode(std::string data) {
     return scEncoded;
 }
 
+// Function to export load and player data to a json file
 void exportJSON() {
     std::ofstream out(jsonFileName);
 
-    // Add Server Load object
-    out << "{\"serverload\": \"" + std::to_string(g_iServerLoad) + "\"";
+    json jExport;
+    jExport["serverload"] = g_iServerLoad;
 
-    // Begin Player array
-    out << ",\"players\": [";
-
+    json jPlayers;
     std::list<HKPLAYERINFO> lstPlayers = HkGetPlayers();
+
     for (std::list<HKPLAYERINFO>::iterator player = lstPlayers.begin();
          player != lstPlayers.end(); player++) {
-        // Add comma is not the first player
-        if (player != lstPlayers.begin())
-            out << ",";
+
+        json jPlayer;
 
         // Add name
-        out << "{\"name\": \"" + encode(wstos(player->wscCharname)) + "\"";
+        jPlayer["name"] = encode(wstos(player->wscCharname));
 
         // Add rank
         int iRank;
         pub::Player::GetRank(player->iClientID, iRank);
-        out << ",\"rank\": \"" + std::to_string(iRank) + "\"";
+        jPlayer["rank"] = std::to_string(iRank);
 
         // Add group
         int groupID = Players.GetGroupID(player->iClientID);
-        out << ",\"group\": \"" + std::to_string(groupID) + "\"";
+        jPlayer["group"] = groupID ? std::to_string(groupID) : "None";
 
         // Add ship
         Archetype::Ship *ship =
             Archetype::GetShip(Players[player->iClientID].iShipArchetype);
-        (ship) ? out << ",\"ship\": \"" + wstos(mapShips[ship->get_id()]) + "\""
-               : out << ",\"ship\": \"Unknown\"";
+        jPlayer["ship"] = (ship) ? wstos(mapShips[ship->get_id()]) : "Unknown";
 
         // Add system
         uint iSystemID;
         pub::Player::GetSystem(player->iClientID, iSystemID);
         const Universe::ISystem *iSys = Universe::get_system(iSystemID);
-        out << ",\"system\": \"" +
-                   wstos(HkGetWStringFromIDS(iSys->strid_name)) + "\"}";
+        jPlayer["system"] = wstos(HkGetWStringFromIDS(iSys->strid_name));
+
+        jPlayers.push_back(jPlayer);
     }
 
-    // End Player array and rest of output
-    out << "]}";
+    jExport["players"] = jPlayers;
+    out << jExport;
     out.close();
 }
 

--- a/plugins/stats_plugin/Main.cpp
+++ b/plugins/stats_plugin/Main.cpp
@@ -4,6 +4,10 @@
 // Includes
 #include "Main.h"
 
+// JSON Library
+using json = nlohmann::json;
+
+// Global Variables
 std::string jsonFileName;
 std::map<uint, std::wstring> mapShips;
 

--- a/plugins/stats_plugin/Main.h
+++ b/plugins/stats_plugin/Main.h
@@ -12,6 +12,8 @@
 #include <string>
 #include <time.h>
 #include <windows.h>
+#include <nlohmann/json.hpp>
+using json = nlohmann::json;
 
 static int set_iPluginDebug = 0;
 PLUGIN_RETURNCODE returncode;

--- a/plugins/stats_plugin/Main.h
+++ b/plugins/stats_plugin/Main.h
@@ -13,7 +13,6 @@
 #include <time.h>
 #include <windows.h>
 #include <nlohmann/json.hpp>
-using json = nlohmann::json;
 
 static int set_iPluginDebug = 0;
 PLUGIN_RETURNCODE returncode;

--- a/project/FLHook.vcxproj
+++ b/project/FLHook.vcxproj
@@ -54,6 +54,17 @@
     <LinkIncremental>false</LinkIncremental>
     <GenerateManifest>true</GenerateManifest>
   </PropertyGroup>
+  <PropertyGroup Label="Vcpkg">
+    <VcpkgEnableManifest>true</VcpkgEnableManifest>
+  </PropertyGroup>
+  <PropertyGroup Label="Vcpkg" Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <VcpkgTriplet>
+    </VcpkgTriplet>
+  </PropertyGroup>
+  <PropertyGroup Label="Vcpkg" Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <VcpkgTriplet>
+    </VcpkgTriplet>
+  </PropertyGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <CustomBuildStep>
       <Command>xcopy /y  "$(OutDir)$(TargetName).lib" "$(SolutionDir)..\FLHookSDK\lib\"

--- a/project/vcpkg.json
+++ b/project/vcpkg.json
@@ -1,0 +1,8 @@
+{
+  "$schema": "https://raw.githubusercontent.com/microsoft/vcpkg/master/scripts/vcpkg.schema.json",
+  "name": "flhook",
+  "version": "2.1.0",
+  "dependencies": [
+    "nlohmann-json"
+  ]
+}

--- a/readme.md
+++ b/readme.md
@@ -214,6 +214,16 @@ Merge requests are welcome. The old Forge SVN repositories are no longer tracked
 
 For any and all support, please visit https://the-starport.net and look for the FLHook forums. Github issues are available for bug reports *only*.
 
+## Compiling the Project
+
+1. Install Visual Studio 2019
+2. Clone https://github.com/microsoft/vcpkg.git
+3. Run bootstrap-vcpkg.bat
+4. In this directory, run `.\vcpkg integrate install`
+5. Clone this repository
+6. Open `project\FLHook.sln`
+7. Ensure you are on `Release` and build the solution.
+
 ## Visual Studio Extension
 
 A visual studio extension is available to ease the plugin creation process. A new project template named "FLHook Plugin Template" will create a ready to use FLHook plugin project for you.


### PR DESCRIPTION
Adding vcpkg allows us to add libraries to FLHook easily.

I have added a json library and swapped the Stats plugin over to using it.

This is laying the framework for other planned plugin improvements which I want to import/export json.