### PR TITLE
Fix CI Build Failure + Update Action

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -16,7 +16,7 @@ jobs:
       
       - run: vcpkg integrate install
 
-      - uses: ilammy/msvc-dev-cmd@v1.5.0
+      - uses: ilammy/msvc-dev-cmd@v1.10.0
         with:
           arch: x86
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,6 +1,6 @@
 on:
   push:
-    branches: [ master ]
+    branches: [ master, fix-ci ]
 
 name: build
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,9 +37,8 @@ jobs:
         with:
           arch: x86
 
-      - uses: actions/setup-dotnet@v2
-        with:
-            dotnet-version: '5.0.x'
+      - name: Install .Net Framework 3.5
+        run: Dism /online /Enable-Feature /FeatureName:"NetFx3"
     
       - name: Compile PlayerControlSetup
         run: msbuild.exe "${env:GITHUB_WORKSPACE}\plugins\playercntl_plugin\setup_src\PlayerCntlSetup.sln" /t:Build /p:Configuration=Release /p:Platform="Any CPU"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,7 +38,7 @@ jobs:
           arch: x86
 
       - name: Compile FLHook
-        run: msbuild.exe "${env:GITHUB_WORKSPACE}\project\FLHook.sln" /t:Build /p:Configuration=Release /p:Platform=Win32"
+        run: msbuild.exe "${env:GITHUB_WORKSPACE}\project\FLHook.sln" /t:Build /p:Configuration=Release /p:Platform=Win32
       
       - name: Get current date
         id: date

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,13 +33,17 @@ jobs:
       
       - run: vcpkg integrate install
 
-      - uses: ilammy/msvc-dev-cmd@v1.5.0
+      - uses: ilammy/msvc-dev-cmd@v1.10.0
         with:
           arch: x86
 
       - name: Compile FLHook
         run: msbuild.exe "${env:GITHUB_WORKSPACE}\project\FLHook.sln" /t:Build /p:Configuration=Release /p:Platform=Win32
 
+      - uses: actions/setup-dotnet@v2
+        with:
+            dotnet-version: '3.5.x'
+    
       - name: Compile PlayerControlSetup
         run: msbuild.exe "${env:GITHUB_WORKSPACE}\plugins\playercntl_plugin\setup_src\PlayerCntlSetup.sln" /t:Build /p:Configuration=Release /p:Platform="Any CPU"
       

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,6 +1,6 @@
 on:
   push:
-    branches: [ master, fix-ci ]
+    branches: [ master ]
 
 name: build
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,12 +37,9 @@ jobs:
         with:
           arch: x86
 
-      - name: Compile FLHook
-        run: msbuild.exe "${env:GITHUB_WORKSPACE}\project\FLHook.sln" /t:Build /p:Configuration=Release /p:Platform=Win32
-
       - uses: actions/setup-dotnet@v2
         with:
-            dotnet-version: '3.5.x'
+            dotnet-version: '5.0.x'
     
       - name: Compile PlayerControlSetup
         run: msbuild.exe "${env:GITHUB_WORKSPACE}\plugins\playercntl_plugin\setup_src\PlayerCntlSetup.sln" /t:Build /p:Configuration=Release /p:Platform="Any CPU"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,11 +37,8 @@ jobs:
         with:
           arch: x86
 
-      - name: Install .Net Framework 3.5
-        run: Dism /online /Enable-Feature /FeatureName:"NetFx3"
-    
-      - name: Compile PlayerControlSetup
-        run: msbuild.exe "${env:GITHUB_WORKSPACE}\plugins\playercntl_plugin\setup_src\PlayerCntlSetup.sln" /t:Build /p:Configuration=Release /p:Platform="Any CPU"
+      - name: Compile FLHook
+        run: msbuild.exe "${env:GITHUB_WORKSPACE}\project\FLHook.sln" /t:Build /p:Configuration=Release /p:Platform=Win32"
       
       - name: Get current date
         id: date


### PR DESCRIPTION
Fix for #62 

I've also removed PlayerControlSetup.exe from the build since the latest Windows runner doesn't seem to have a useable .NET Framework 3.5. We're also in the process of migrating away from this plugin anyway.