### PR TITLE
Fix typo preventing vcpkg initialization

### DIFF
--- a/project/FLHook.vcxproj
+++ b/project/FLHook.vcxproj
@@ -117,7 +117,7 @@
 			</Command>
     </PostBuildEvent>
     <PreBuildEvent>
-      <Command>$(SolutionDir)..\vcpkg\bookstrap-vcpkg.bat
+      <Command>$(SolutionDir)..\vcpkg\bootstrap-vcpkg.bat
 $(SolutionDir)..\vcpkg\vcpkg.exe integrate install</Command>
     </PreBuildEvent>
   </ItemDefinitionGroup>


### PR DESCRIPTION
Building solution from VS will fail on a fresh download because the path to vcpkg boostrap script contains a typo.