### PR TITLE
Fix reflection error for Template plugin

### DIFF
--- a/plugins/_plugin_template/Main.cpp
+++ b/plugins/_plugin_template/Main.cpp
@@ -96,6 +96,8 @@ namespace Plugins::Template
 
 using namespace Plugins::Template;
 
+REFL_AUTO(type(Config))
+
 DefaultDllMainSettings(LoadSettings)
 
 extern "C" EXPORT void ExportPluginInfo(PluginInfo* pi)


### PR DESCRIPTION
The template plugin is throwing compile errors complaining that it's Config struct is not reflectable. After looking over the other plugins, it seems like this line was missing from the template. Now it should compile correctly and new plugins can be based off it.