### PR TITLE
Updating timers to new mechanism

### DIFF
--- a/plugins/base/Main.cpp
+++ b/plugins/base/Main.cpp
@@ -376,8 +376,11 @@ void LoadSettingsActual()
 }
 
 ///////////////////////////////////////////////////////////////////////////////////////////////////////////////
+const std::vector<Timer> timers = {
+	{PlayerBaseLogicMainLoop, 1}
+};
 
-void TimerCheckKick()
+void PlayerBaseLogicMainLoop()
 {
 	if (load_settings_required)
 	{
@@ -1458,6 +1461,7 @@ extern "C" EXPORT void ExportPluginInfo(PluginInfo* pi)
 	pi->shortName("base");
 	pi->mayUnload(true);
 	pi->commands(commands);
+	pi->timers(timers);
 	pi->returnCode(&returncode);
 	pi->versionMajor(PluginMajorVersion::VERSION_04);
 	pi->versionMinor(PluginMinorVersion::VERSION_00);
@@ -1482,7 +1486,6 @@ extern "C" EXPORT void ExportPluginInfo(PluginInfo* pi)
 	pi->emplaceHook(HookedCall::IServerImpl__ReqChangeCash, &ReqChangeCash);
 	pi->emplaceHook(HookedCall::IServerImpl__ReqSetCash, &ReqSetCash);
 	pi->emplaceHook(HookedCall::IServerImpl__ReqEquipment, &ReqEquipment);
-	pi->emplaceHook(HookedCall::FLHook__TimerCheckKick, &TimerCheckKick);
 	pi->emplaceHook(HookedCall::FLHook__UserCommand__Process, &UserCmd_Process);
 	pi->emplaceHook(HookedCall::FLHook__AdminCommand__Process, &ExecuteCommandString);
 	pi->emplaceHook(HookedCall::IEngine__CShip__Destroy, &CShip_destroy);

--- a/plugins/bountyhunt/Main.cpp
+++ b/plugins/bountyhunt/Main.cpp
@@ -237,34 +237,11 @@ namespace Plugins::BountyHunt
 		}
 	}
 
-	// Hooks
-	using TimerFunc = void (*)();
-	struct Timer
-	{
-		TimerFunc proc;
-		mstime intervalMs;
-		mstime lastCall;
+	// Timer Hook
+	const std::vector<Timer> timers = {
+	    {BhTimeOutCheck, 60}
 	};
 
-	Timer Timers[] = {
-	    {BhTimeOutCheck, 2017, 0},
-	};
-
-	/** @ingroup BountyHunt
-	 * @brief Calls our BhTimeOutCheck timer.
-	 */
-	int __stdcall Update()
-	{
-		for (uint i = 0; (i < sizeof(Timers) / sizeof(Timer)); i++)
-		{
-			if ((timeInMS() - Timers[i].lastCall) >= Timers[i].intervalMs)
-			{
-				Timers[i].lastCall = timeInMS();
-				Timers[i].proc();
-			}
-		}
-		return 0;
-	}
 
 	/** @ingroup BountyHunt
 	 * @brief Hook for SendDeathMsg to call BillCheck
@@ -329,10 +306,10 @@ DefaultDllMainSettings(LoadSettings)
 	pi->shortName("bountyhunt");
 	pi->mayUnload(false);
 	pi->commands(commands);
+	pi->timers(timers);
 	pi->returnCode(&global->returnCode);
 	pi->versionMajor(PluginMajorVersion::VERSION_04);
 	pi->versionMinor(PluginMinorVersion::VERSION_00);
-	pi->emplaceHook(HookedCall::IServerImpl__Update, &Update);
 	pi->emplaceHook(HookedCall::IEngine__SendDeathMessage, &SendDeathMsg);
 	pi->emplaceHook(HookedCall::FLHook__LoadSettings, &LoadSettings, HookStep::After);
 	pi->emplaceHook(HookedCall::IServerImpl__DisConnect, &DisConnect);

--- a/plugins/cargo_drop/Main.cpp
+++ b/plugins/cargo_drop/Main.cpp
@@ -54,6 +54,10 @@ namespace Plugins::CargoDrop
 		global->config = std::make_unique<Config>(config);
 	}
 
+	const std::vector<Timer> timers = {
+		{OneSecondTimer, 1}
+	};
+
 	/** @ingroup CargoDrop
 	 * @brief Timer that checks if a player has disconnected and punished them if so.
 	 */
@@ -213,12 +217,12 @@ DefaultDllMainSettings(LoadSettings)
 	pi->name("Cargo Drop");
 	pi->shortName("cargo_drop");
 	pi->mayUnload(true);
+	pi->timers(timers);
 	pi->returnCode(&global->returnCode);
 	pi->versionMajor(PluginMajorVersion::VERSION_04);
 	pi->versionMinor(PluginMinorVersion::VERSION_00);
 	pi->emplaceHook(HookedCall::FLHook__ClearClientInfo, &ClearClientInfo);
 	pi->emplaceHook(HookedCall::FLHook__LoadSettings, &LoadSettings, HookStep::After);
-	pi->emplaceHook(HookedCall::FLHook__TimerCheckKick, &OneSecondTimer);
 	pi->emplaceHook(HookedCall::IEngine__SendDeathMessage, &SendDeathMsg);
 	pi->emplaceHook(HookedCall::IServerImpl__SPObjUpdate, &SPObjUpdate);
 }

--- a/plugins/cargo_drop/Main.cpp
+++ b/plugins/cargo_drop/Main.cpp
@@ -54,14 +54,10 @@ namespace Plugins::CargoDrop
 		global->config = std::make_unique<Config>(config);
 	}
 
-	const std::vector<Timer> timers = {
-		{OneSecondTimer, 1}
-	};
-
 	/** @ingroup CargoDrop
 	 * @brief Timer that checks if a player has disconnected and punished them if so.
 	 */
-	void OneSecondTimer()
+	void DisconnectCheck()
 	{
 		// Disconnecting while interacting checks.
 		for (auto& [client, snd] : global->info)
@@ -140,6 +136,10 @@ namespace Plugins::CargoDrop
 			}
 		}
 	}
+
+	const std::vector<Timer> timers = {
+		{DisconnectCheck, 1}
+	};
 
 	/** @ingroup CargoDrop
 	 * @brief Hook for ship destruction. It's easier to hook this than the PlayerDeath one. Drop a percentage of cargo + some loot representing ship bits.

--- a/plugins/crash_catcher/Main.cpp
+++ b/plugins/crash_catcher/Main.cpp
@@ -78,14 +78,10 @@ namespace Plugins::CrashCatcher
 		}
 	}
 
-	const std::vector<Timer> timers = {
-		{OneSecondTimer, 1}
-	};
-
 	/** @ingroup CrashCatcher
 	 * @brief Action the save times recorded in the above two functions
 	 */
-	void OneSecondTimer()
+	void SaveCrashingCharacter()
 	{
 		mstime currTime = GetTimeInMS();
 		for (auto& t : global->mapSaveTimes)
@@ -99,6 +95,10 @@ namespace Plugins::CrashCatcher
 			}
 		}
 	}
+
+	const std::vector<Timer> timers = {
+		{SaveCrashingCharacter, 1}
+	};
 
 	/** @ingroup CrashCatcher
 	 * @brief Originally in Main.cpp of PlayerControl

--- a/plugins/crash_catcher/Main.cpp
+++ b/plugins/crash_catcher/Main.cpp
@@ -78,6 +78,10 @@ namespace Plugins::CrashCatcher
 		}
 	}
 
+	const std::vector<Timer> timers = {
+		{OneSecondTimer, 1}
+	};
+
 	/** @ingroup CrashCatcher
 	 * @brief Action the save times recorded in the above two functions
 	 */
@@ -619,12 +623,12 @@ extern "C" EXPORT void ExportPluginInfo(PluginInfo* pi)
 	pi->name("Crash Catcher");
 	pi->shortName("CrashCatcher");
 	pi->mayUnload(true);
+	pi->timers(timers);
 	pi->returnCode(&global->returncode);
 	pi->versionMajor(PluginMajorVersion::VERSION_04);
 	pi->versionMinor(PluginMinorVersion::VERSION_00);
 	pi->emplaceHook(HookedCall::FLHook__LoadSettings, &Init, HookStep::After);
 	pi->emplaceHook(HookedCall::IServerImpl__RequestBestPath, &RequestBestPath);
-	pi->emplaceHook(HookedCall::FLHook__TimerCheckKick, &OneSecondTimer);
 	pi->emplaceHook(HookedCall::IServerImpl__TractorObjects, &TractorObjects);
 	pi->emplaceHook(HookedCall::IServerImpl__JettisonCargo, &JettisonCargo);
 }

--- a/plugins/event/Main.cpp
+++ b/plugins/event/Main.cpp
@@ -91,10 +91,6 @@ namespace Plugins::Event
 		Console::ConInfo(L"NpcMissionSettings loaded [%d]", global->NpcMissions.size());
 	}
 
-	const std::vector<Timer> timers = {
-		{SaveMissionStatus, 100}
-	};
-
 	/** @ingroup Event
 	 * @brief Save mission status every 100 seconds.
 	 */
@@ -131,6 +127,10 @@ namespace Plugins::Event
 		out.close();
 
 	}
+
+	const std::vector<Timer> timers = {
+		{SaveMissionStatus, 100}
+	};
 
 	/** @ingroup Event
 	 * @brief Hook on ShipDestroyed to see if an NPC mission needs to be updated.

--- a/plugins/event/Main.cpp
+++ b/plugins/event/Main.cpp
@@ -91,44 +91,45 @@ namespace Plugins::Event
 		Console::ConInfo(L"NpcMissionSettings loaded [%d]", global->NpcMissions.size());
 	}
 
+	const std::vector<Timer> timers = {
+		{SaveMissionStatus, 100}
+	};
+
 	/** @ingroup Event
 	 * @brief Save mission status every 100 seconds.
 	 */
-	void TimerCheckKick()
+	void SaveMissionStatus()
 	{
-		if ((time(0) % 100) == 0)
+		std::ofstream out("flhook_plugins/event.json");
+
+		nlohmann::json jExport;
+
+		for (auto& mission : global->CargoMissions)
 		{
-			std::ofstream out("flhook_plugins/event.json");
-
-			nlohmann::json jExport;
-
-			for (auto& mission : global->CargoMissions)
-			{
-				nlohmann::json jMission;
-				jMission["nickname"] = mission.nickname;
-				jMission["base"] = mission.base;
-				jMission["item"] = mission.item;
-				jMission["current_amount"] = mission.current_amount;
-				jMission["required_amount"] = mission.required_amount;
-				jExport["CargoMissions"].push_back(jMission);
-			}
-
-			for (auto& mission : global->NpcMissions)
-			{
-				nlohmann::json jMission;
-				jMission["nickname"] = mission.nickname;
-				jMission["system"] = mission.system;
-				jMission["reputation"] = mission.reputation;
-				jMission["sector"] = mission.sector;
-				jMission["current_amount"] = mission.current_amount;
-				jMission["required_amount"] = mission.required_amount;
-				jExport["NpcMissions"].push_back(jMission);
-			}
-
-			out << jExport;
-			out.close();
-
+			nlohmann::json jMission;
+			jMission["nickname"] = mission.nickname;
+			jMission["base"] = mission.base;
+			jMission["item"] = mission.item;
+			jMission["current_amount"] = mission.current_amount;
+			jMission["required_amount"] = mission.required_amount;
+			jExport["CargoMissions"].push_back(jMission);
 		}
+
+		for (auto& mission : global->NpcMissions)
+		{
+			nlohmann::json jMission;
+			jMission["nickname"] = mission.nickname;
+			jMission["system"] = mission.system;
+			jMission["reputation"] = mission.reputation;
+			jMission["sector"] = mission.sector;
+			jMission["current_amount"] = mission.current_amount;
+			jMission["required_amount"] = mission.required_amount;
+			jExport["NpcMissions"].push_back(jMission);
+		}
+
+		out << jExport;
+		out.close();
+
 	}
 
 	/** @ingroup Event
@@ -227,11 +228,11 @@ extern "C" EXPORT void ExportPluginInfo(PluginInfo* pi)
 	pi->name("Event");
 	pi->shortName("event");
 	pi->mayUnload(true);
+	pi->timers(timers);
 	pi->returnCode(&global->returncode);
 	pi->versionMajor(PluginMajorVersion::VERSION_04);
 	pi->versionMinor(PluginMinorVersion::VERSION_00);
 	pi->emplaceHook(HookedCall::FLHook__LoadSettings, &LoadSettings, HookStep::After);
-	pi->emplaceHook(HookedCall::FLHook__TimerCheckKick, &TimerCheckKick);
 	pi->emplaceHook(HookedCall::IEngine__ShipDestroyed, &ShipDestroyed);
 	pi->emplaceHook(HookedCall::IServerImpl__GFGoodBuy, &GFGoodBuy);
 	pi->emplaceHook(HookedCall::IServerImpl__GFGoodSell, &GFGoodSell);

--- a/plugins/minecontrol/Main.cpp
+++ b/plugins/minecontrol/Main.cpp
@@ -173,10 +173,6 @@ namespace Plugins::MiningControl
 		}
 	}
 
-	const std::vector<Timer> timers = {
-		{UpdateStatsFile, 60}
-	};
-
 	/** @ingroup MiningControl
 	 * @brief Timer hook to update mining stats to file
 	 */
@@ -199,6 +195,10 @@ namespace Plugins::MiningControl
 		}
 		Serializer::SaveToJson(stats);
 	}
+
+	const std::vector<Timer> timers = {
+		{UpdateStatsFile, 60}
+	};
 
 	/** @ingroup MiningControl
 	 * @brief Clear client info when a client connects.

--- a/plugins/minecontrol/Main.cpp
+++ b/plugins/minecontrol/Main.cpp
@@ -173,30 +173,31 @@ namespace Plugins::MiningControl
 		}
 	}
 
+	const std::vector<Timer> timers = {
+		{UpdateStatsFile, 60}
+	};
+
 	/** @ingroup MiningControl
 	 * @brief Timer hook to update mining stats to file
 	 */
-	void TimerCheckKick()
+	void UpdateStatsFile()
 	{
-		// Perform 60 second tasks.
-		if ((time(0) % 60) == 0)
+		
+		MiningStats stats;
+		// Recharge the fields
+		for (auto& i : global->ZoneBonus)
 		{
-			MiningStats stats;
-			// Recharge the fields
-			for (auto& i : global->ZoneBonus)
-			{
-				i.second.CurrentReserve += i.second.RechargeRate;
-				if (i.second.CurrentReserve > i.second.MaxReserve)
-					i.second.CurrentReserve = i.second.MaxReserve;
+			i.second.CurrentReserve += i.second.RechargeRate;
+			if (i.second.CurrentReserve > i.second.MaxReserve)
+				i.second.CurrentReserve = i.second.MaxReserve;
 
-				ZoneStats zs;
-				zs.CurrentReserve = i.second.CurrentReserve;
-				zs.Mined = i.second.Mined;
-				zs.Zone = i.second.Zone;
-				stats.Stats.emplace_back(zs);
-			}
-			Serializer::SaveToJson(stats);
+			ZoneStats zs;
+			zs.CurrentReserve = i.second.CurrentReserve;
+			zs.Mined = i.second.Mined;
+			zs.Zone = i.second.Zone;
+			stats.Stats.emplace_back(zs);
 		}
+		Serializer::SaveToJson(stats);
 	}
 
 	/** @ingroup MiningControl
@@ -583,6 +584,7 @@ extern "C" EXPORT void ExportPluginInfo(PluginInfo* pi)
 	pi->name("Mine Control");
 	pi->shortName("minecontrol");
 	pi->mayUnload(true);
+	pi->timers(timers);
 	pi->returnCode(&global->returnCode);
 	pi->versionMajor(PluginMajorVersion::VERSION_04);
 	pi->versionMinor(PluginMinorVersion::VERSION_00);
@@ -591,5 +593,4 @@ extern "C" EXPORT void ExportPluginInfo(PluginInfo* pi)
 	pi->emplaceHook(HookedCall::IServerImpl__PlayerLaunch, &PlayerLaunch);
 	pi->emplaceHook(HookedCall::IServerImpl__MineAsteroid, &MineAsteroid);
 	pi->emplaceHook(HookedCall::IServerImpl__SPMunitionCollision, &SPMunitionCollision);
-	pi->emplaceHook(HookedCall::FLHook__TimerCheckKick, &TimerCheckKick);
 }

--- a/plugins/restarts/Main.cpp
+++ b/plugins/restarts/Main.cpp
@@ -141,7 +141,11 @@ namespace Plugins::Restart
 
 	/* Hooks */
 
-	void OneSecondTimer()
+	const std::vector<Timer> timers = {
+		{ProcessPendingRestarts, 1}
+	};
+
+	void ProcessPendingRestarts()
 	{
 		while (global->pendingRestarts.size())
 		{
@@ -202,9 +206,9 @@ DefaultDllMainSettings(LoadSettings)
 	pi->shortName("restarts");
 	pi->mayUnload(true);
 	pi->commands(commands);
+	pi->timers(timers);
 	pi->returnCode(&global->returnCode);
 	pi->versionMajor(PluginMajorVersion::VERSION_04);
 	pi->versionMinor(PluginMinorVersion::VERSION_00);
 	pi->emplaceHook(HookedCall::FLHook__LoadSettings, &LoadSettings, HookStep::After);
-	pi->emplaceHook(HookedCall::FLHook__TimerCheckKick, &OneSecondTimer);
 }

--- a/plugins/restarts/Main.cpp
+++ b/plugins/restarts/Main.cpp
@@ -140,11 +140,6 @@ namespace Plugins::Restart
 	}
 
 	/* Hooks */
-
-	const std::vector<Timer> timers = {
-		{ProcessPendingRestarts, 1}
-	};
-
 	void ProcessPendingRestarts()
 	{
 		while (global->pendingRestarts.size())
@@ -185,6 +180,10 @@ namespace Plugins::Restart
 			}
 		}
 	}
+
+	const std::vector<Timer> timers = {
+		{ProcessPendingRestarts, 1}
+	};
 
 	// Client command processing
 	const std::vector commands = {{

--- a/plugins/tempban/Main.cpp
+++ b/plugins/tempban/Main.cpp
@@ -8,7 +8,11 @@ namespace Plugins::Tempban
 	Check if TempBans exceeded
 	**************************************************************************************************************/
 
-	void TimerCheckKick()
+	const std::vector<Timer> timers = {
+		{ClearExpiredTempbans, 15}
+	};
+
+	void ClearExpiredTempbans()
 	{
 		// timed out tempbans get deleted here
 
@@ -135,10 +139,10 @@ extern "C" EXPORT void ExportPluginInfo(PluginInfo* pi)
 	pi->name(TempBanCommunicator::pluginName);
 	pi->shortName("tempban");
 	pi->mayUnload(true);
+	pi->timers(timers);
 	pi->returnCode(&global->returncode);
 	pi->versionMajor(PluginMajorVersion::VERSION_04);
 	pi->versionMinor(PluginMinorVersion::VERSION_00);
-	pi->emplaceHook(HookedCall::FLHook__TimerCheckKick, &TimerCheckKick);
 	pi->emplaceHook(HookedCall::IServerImpl__Login, &Login, HookStep::After);
 	pi->emplaceHook(HookedCall::FLHook__AdminCommand__Process, &ExecuteCommandString);
 	pi->emplaceHook(HookedCall::FLHook__AdminCommand__Help, &CmdHelp);

--- a/plugins/tempban/Main.cpp
+++ b/plugins/tempban/Main.cpp
@@ -8,10 +8,6 @@ namespace Plugins::Tempban
 	Check if TempBans exceeded
 	**************************************************************************************************************/
 
-	const std::vector<Timer> timers = {
-		{ClearExpiredTempbans, 15}
-	};
-
 	void ClearExpiredTempbans()
 	{
 		// timed out tempbans get deleted here
@@ -27,6 +23,10 @@ namespace Plugins::Tempban
 			}
 		}
 	}
+
+	const std::vector<Timer> timers = {
+		{ClearExpiredTempbans, 15}
+	};
 
 	///////////////////////////////////////////////////////////////////////////////////////////////////////////////
 

--- a/plugins/wardrobe/Main.cpp
+++ b/plugins/wardrobe/Main.cpp
@@ -96,7 +96,11 @@ namespace Plugins::Wardrobe
 		}
 	}
 
-	void TimerCheckKick()
+	const std::vector<Timer> timers = {
+		{ProcessWardrobeRestarts, 1}
+	};
+
+	void ProcessWardrobeRestarts()
 	{
 		while (!global->pendingRestarts.empty())
 		{
@@ -166,9 +170,9 @@ extern "C" EXPORT void ExportPluginInfo(PluginInfo* pi)
 	pi->shortName("wardrobe");
 	pi->mayUnload(true);
 	pi->commands(commands);
+	pi->timers(timers);
 	pi->returnCode(&global->returncode);
 	pi->versionMajor(PluginMajorVersion::VERSION_04);
 	pi->versionMinor(PluginMinorVersion::VERSION_00);
 	pi->emplaceHook(HookedCall::FLHook__LoadSettings, &LoadSettings, HookStep::After);
-	pi->emplaceHook(HookedCall::FLHook__TimerCheckKick, &TimerCheckKick);
 }

--- a/plugins/wardrobe/Main.cpp
+++ b/plugins/wardrobe/Main.cpp
@@ -96,10 +96,6 @@ namespace Plugins::Wardrobe
 		}
 	}
 
-	const std::vector<Timer> timers = {
-		{ProcessWardrobeRestarts, 1}
-	};
-
 	void ProcessWardrobeRestarts()
 	{
 		while (!global->pendingRestarts.empty())
@@ -138,6 +134,10 @@ namespace Plugins::Wardrobe
 			}
 		}
 	}
+
+	const std::vector<Timer> timers = {
+		{ProcessWardrobeRestarts, 1}
+	};
 
 	void LoadSettings()
 	{

--- a/source/Features/PluginManager.cpp
+++ b/source/Features/PluginManager.cpp
@@ -188,6 +188,7 @@ void PluginManager::load(const std::wstring& fileName, CCmds* adminInterface, bo
 		FreeLibrary(plugin.dll);
 		return;
 	}
+	plugin.timers = std::move(pi->timers_);
 
 	// Clean up the command list
 	pi->commands_.erase(std::remove_if(pi->commands_.begin(), pi->commands_.end(),

--- a/source/HkClientServerInterface.cpp
+++ b/source/HkClientServerInterface.cpp
@@ -71,7 +71,7 @@ namespace IServerImplHook
 		{
 			for (auto& timer : plugin.timers)
 			{
-				if ((currentTime - timer.lastTime) >= (timer.intervalInSeconds * 100))
+				if ((currentTime - timer.lastTime) >= (timer.intervalInSeconds * 1000))
 				{
 					timer.lastTime = currentTime;
 					timer.func();


### PR DESCRIPTION
Resolves #114 

Fixed the issue where the timers were not being applied to PluginData (and therefore invoked)

Updated Base, BountyHunt, Cargo_Drop, Crash_Catcher, Event, MineControl, Restarts, TempBan, Wardrobe

Potential update  possible for Cloak and Condata, but those seem like something we want to fire more often than once a second, so I left them alone.