### PR TITLE
Crash fix - Rename plugin

### DIFF
--- a/plugins/message/Main.cpp
+++ b/plugins/message/Main.cpp
@@ -585,7 +585,7 @@ namespace Plugins::Message
 
 	void UserCmd_SMsg8(ClientId& client, const std::wstring& wscParam) { SendPresetSystemMessage(client, 8); }
 
-	void UserCmd_SMsg9(ClientId& client, const std::wstring& wscParam) { SendPresetSystemMessage(client, 0); }
+	void UserCmd_SMsg9(ClientId& client, const std::wstring& wscParam) { SendPresetSystemMessage(client, 9); }
 
 	/** @ingroup Message
 	 * @brief User Commands for /l0-9

--- a/plugins/rename/Main.cpp
+++ b/plugins/rename/Main.cpp
@@ -305,7 +305,7 @@ namespace Plugins::Rename
 			}
 		}
 
-		while (global->pendingMoves.empty())
+		while (!global->pendingMoves.empty())
 		{
 			Move o = global->pendingMoves.front();
 			if (Hk::Client::GetClientIdFromCharName(o.destinationCharName) != -1)


### PR DESCRIPTION
Pending Character Moves are no longer processed when the list is empty.