### PR TITLE
BountyHunt will now drop upon changing character as the hunted

### DIFF
--- a/plugins/bountyhunt/Main.cpp
+++ b/plugins/bountyhunt/Main.cpp
@@ -266,11 +266,7 @@ namespace Plugins::BountyHunt
 		}
 	}
 
-	/** @ingroup BountyHunt
-	 * @brief Hook for Disconnect to see if the player had a bounty on them
-	 */
-	void __stdcall DisConnect(ClientId& client, enum EFLConnection& state)
-	{
+	void checkIfPlayerFled(ClientId& client) {
 		for (auto& it : global->bountyHunt)
 		{
 			if (it.targetId == client)
@@ -285,6 +281,22 @@ namespace Plugins::BountyHunt
 				return;
 			}
 		}
+	}
+
+	/** @ingroup BountyHunt
+	 * @brief Hook for Disconnect to see if the player had a bounty on them
+	 */
+	void __stdcall DisConnect(ClientId& client, enum EFLConnection& state)
+	{
+		checkIfPlayerFled(client);
+	}
+
+	/** @ingroup BountyHunt
+	 * @brief Hook for CharacterSelect to see if the player had a bounty on them
+	 */
+	void __stdcall CharacterSelect(std::string& szCharFilename, ClientId& client)
+	{
+		checkIfPlayerFled(client);
 	}
 
 	// Client command processing
@@ -325,4 +337,5 @@ DefaultDllMainSettings(LoadSettings)
 	pi->emplaceHook(HookedCall::IEngine__SendDeathMessage, &SendDeathMsg);
 	pi->emplaceHook(HookedCall::FLHook__LoadSettings, &LoadSettings, HookStep::After);
 	pi->emplaceHook(HookedCall::IServerImpl__DisConnect, &DisConnect);
+	pi->emplaceHook(HookedCall::IServerImpl__CharacterSelect, &CharacterSelect, HookStep::After);
 }

--- a/plugins/bountyhunt/Main.cpp
+++ b/plugins/bountyhunt/Main.cpp
@@ -17,7 +17,10 @@
  * @code
  * {
  *     "enableBountyHunt": true,
- *     "levelProtect": 0
+ *     "levelProtect": 0,
+ *     "minimalHuntTime": 1,
+ *     "maximumHuntTime": 240,
+ *     "defaultHuntTime": 30
  * }
  * @endcode
  *
@@ -104,10 +107,15 @@ namespace Plugins::BountyHunt
 			PrintUserCmdText(client, L"Low level players may not be hunted.");
 			return;
 		}
-		if (time < 1 || time > 240)
+
+		// clamp the hunting time to configured range, or set default if not specified
+		if (time)
 		{
-			PrintUserCmdText(client, L"Hunting time: 30 minutes.");
-			time = 30;
+			time = min(global->config->maximumHuntTime, max(global->config->minimalHuntTime, time));
+		}
+		else
+		{
+			time = global->config->defaultHuntTime;
 		}
 
 		int clientCash;

--- a/plugins/bountyhunt/Main.cpp
+++ b/plugins/bountyhunt/Main.cpp
@@ -308,7 +308,7 @@ namespace Plugins::BountyHunt
 ///////////////////////////////////////////////////////////////////////////////////////////////////////////////
 using namespace Plugins::BountyHunt;
 
-REFL_AUTO(type(Config), field(enableBountyHunt), field(levelProtect))
+REFL_AUTO(type(Config), field(enableBountyHunt), field(levelProtect), field(minimalHuntTime), field(maximumHuntTime), field(defaultHuntTime))
 
 DefaultDllMainSettings(LoadSettings)
 

--- a/plugins/bountyhunt/Main.h
+++ b/plugins/bountyhunt/Main.h
@@ -25,6 +25,9 @@ namespace Plugins::BountyHunt
 		// Reflectable fields
 		bool enableBountyHunt = true;
 		int levelProtect = 0;
+		uint minimalHuntTime = 1;
+		uint maximumHuntTime = 240;
+		uint defaultHuntTime = 30;
 	};
 
 	


### PR DESCRIPTION
Bounties are listed using shipnames, there's no reason for them to carry on to other ships on the account, as well as having situations where there's an active bounty for PirateJoe, when the player is currently flying his TraderJimmy on the same account.