### PR TITLE
Fixing of issue #173, Introduction of Concepts for flhook templates, Initial Set-up of multiline print user commands

### DIFF
--- a/include/Tools/Concepts.hpp
+++ b/include/Tools/Concepts.hpp
@@ -2,5 +2,5 @@
 #include <string>
 #include <type_traits>
 
-template <typename T>
+template<typename T>
 concept StringRestriction = std::is_same<std::string, T>::value || std::is_same<std::wstring, T>::value;

--- a/include/Tools/Concepts.hpp
+++ b/include/Tools/Concepts.hpp
@@ -1,0 +1,6 @@
+#pragma once
+#include <string>
+#include <type_traits>
+
+template <typename T>
+concept StringRestriction = std::is_same<std::string, T>::value || std::is_same<std::wstring, T>::value;

--- a/include/Tools/Hk.hpp
+++ b/include/Tools/Hk.hpp
@@ -17,6 +17,7 @@ extern DLL st6_free_t st6_free;
 #include <ext/Singleton.h>
 
 #include "Structs.hpp"
+#include "Concepts.hpp"
 
 #include "Deps.hpp"
 struct CARGO_INFO;

--- a/include/Tools/Hk.hpp
+++ b/include/Tools/Hk.hpp
@@ -30,7 +30,7 @@ namespace Hk
 	{
 		std::chrono::seconds Unix();
 		std::chrono::milliseconds UnixMilliseconds();
-		
+
 		DLL uint GetUnix();
 
 		template<typename T>
@@ -311,8 +311,8 @@ namespace Hk
 	namespace ZoneUtilities
 	{
 		DLL void ReadUniverse(std::multimap<uint, LootableZone, std::less<>>* zones);
-		DLL void ReadLootableZone(std::multimap<uint, LootableZone, std::less<>>& zones, const std::string& systemNick,
-		    const std::string& defaultZoneNick, const std::string& file);
+		DLL void ReadLootableZone(
+		    std::multimap<uint, LootableZone, std::less<>>& zones, const std::string& systemNick, const std::string& defaultZoneNick, const std::string& file);
 		DLL void ReadSystemLootableZones(std::multimap<uint, LootableZone, std::less<>>& zones, const std::string& systemNick, const std::string& file);
 		DLL void ReadSystemZones(std::multimap<uint, LootableZone, std::less<>>& zones, const std::string& systemNick, const std::string& file);
 		DLL bool InZone(uint systemId, const Vector& pos, Zone& rlz);

--- a/include/Tools/Utils.hpp
+++ b/include/Tools/Utils.hpp
@@ -77,7 +77,8 @@ inline int64 ToInt64(const std::wstring& str)
 
 inline uint ToUInt(const std::wstring& wscStr)
 {
-	if (wscStr.find(L"-") != std::wstring::npos) {
+	if (wscStr.find(L"-") != std::wstring::npos)
+	{
 		return 0;
 	}
 	return wcstoul(wscStr.c_str(), nullptr, 10);
@@ -107,44 +108,43 @@ inline std::wstring XMLText(const std::wstring& text)
 }
 
 template<typename TStr, typename TChar>
-inline TStr GetParam(const TStr& line, TChar wcSplitChar, uint iPos)
+inline TStr GetParam(const TStr& line, TChar splitChar, uint pos) requires StringRestriction<TStr>
 {
 	uint i, j;
 
-	TStr wscResult;
-	for (i = 0, j = 0; (i <= iPos) && (j < line.length()); j++)
+	TStr result;
+	for (i = 0, j = 0; (i <= pos) && (j < line.length()); j++)
 	{
-		if (line[j] == wcSplitChar)
+		if (line[j] == splitChar)
 		{
-			while (((j + 1) < line.length()) && (line[j + 1] == wcSplitChar))
+			while (((j + 1) < line.length()) && (line[j + 1] == splitChar))
 				j++; // skip "whitechar"
 
 			i++;
 			continue;
 		}
 
-		if (i == iPos)
-			wscResult += line[j];
+		if (i == pos)
+			result += line[j];
 	}
-
-	return wscResult;
+	return result;
 }
 
 template<typename TString, typename TChar>
-TString GetParamToEnd(const TString& wscLine, TChar wcSplitChar, uint iPos)
+TString GetParamToEnd(const TString& line, TChar splitChar, uint pos) requires StringRestriction<TString>
 {
-	for (uint i = 0, j = 0; (i <= iPos) && (j < wscLine.length()); j++)
+	for (uint i = 0, j = 0; (i <= pos) && (j < line.length()); j++)
 	{
-		if (wscLine[j] == wcSplitChar)
+		if (line[j] == splitChar)
 		{
-			while (((j + 1) < wscLine.length()) && (wscLine[j + 1] == wcSplitChar))
+			while (((j + 1) < line.length()) && (line[j + 1] == splitChar))
 				j++; // skip "whitechar"
 			i++;
 			continue;
 		}
-		if (i == iPos)
+		if (i == pos)
 		{
-			return wscLine.substr(j);
+			return line.substr(j);
 		}
 	}
 
@@ -152,7 +152,7 @@ TString GetParamToEnd(const TString& wscLine, TChar wcSplitChar, uint iPos)
 }
 
 template<typename TString, typename TTStr, typename TTTStr>
-TString ReplaceStr(const TString& source, const TTStr& searchForRaw, const TTTStr& replaceWithRaw)
+TString ReplaceStr(const TString& source, const TTStr& searchForRaw, const TTTStr& replaceWithRaw) requires StringRestriction<TString>
 {
 	const TString searchFor = searchForRaw;
 	const TString replaceWith = replaceWithRaw;
@@ -178,79 +178,77 @@ std::wstring ToMoneyStr(T cash)
 	return ss.str();
 }
 
-inline float ToFloat(const std::wstring& wscStr)
+inline float ToFloat(const std::wstring& string)
 {
-	return wcstof(wscStr.c_str(), nullptr);
+	return wcstof(string.c_str(), nullptr);
 }
 
-inline FARPROC PatchCallAddr(char* hMod, DWORD dwInstallAddress, char* dwHookFunction)
+inline FARPROC PatchCallAddr(char* mod, DWORD installAddress, char* hookFunction)
 {
 	DWORD dwRelAddr;
-	ReadProcMem(hMod + dwInstallAddress + 1, &dwRelAddr, 4);
+	ReadProcMem(mod + installAddress + 1, &dwRelAddr, 4);
 
-	DWORD dwOffset = (DWORD)dwHookFunction - (DWORD)(hMod + dwInstallAddress + 5);
-	WriteProcMem(hMod + dwInstallAddress + 1, &dwOffset, 4);
+	DWORD dwOffset = (DWORD)hookFunction - (DWORD)(mod + installAddress + 5);
+	WriteProcMem(mod + installAddress + 1, &dwOffset, 4);
 
-	return (FARPROC)(hMod + dwRelAddr + dwInstallAddress + 5);
+	return (FARPROC)(mod + dwRelAddr + installAddress + 5);
 }
 
-inline std::wstring ToLower(std::wstring wscStr)
+inline std::wstring ToLower(std::wstring string)
 {
-	std::transform(wscStr.begin(), wscStr.end(), wscStr.begin(), towlower);
-	return wscStr;
+	std::transform(string.begin(), string.end(), string.begin(), towlower);
+	return string;
 }
 
-inline std::string ToLower(std::string scStr)
+inline std::string ToLower(std::string string)
 {
-	std::transform(scStr.begin(), scStr.end(), scStr.begin(), tolower);
-	return scStr;
+	std::transform(string.begin(), string.end(), string.begin(), tolower);
+	return string;
 }
 
 /**
 Remove leading and trailing spaces from the std::string  ~FlakCommon by Motah.
 */
 template<typename Str>
-Str Trim(const Str& scIn)
+Str Trim(const Str& stringInput) requires StringRestriction <Str>
 {
-	if (scIn.empty())
-		return scIn;
+	if (stringInput.empty())
+		return stringInput;
 
 	using Char = typename Str::value_type;
-	constexpr auto trimmable = []() constexpr
-	{
+	constexpr auto trimmable = []() constexpr {
 		if constexpr (std::is_same_v<Char, char>)
 			return " \t\n\r";
 		else if constexpr (std::is_same_v<Char, wchar_t>)
 			return L" \t\n\r";
-	}
-	();
+	}();
 
-	auto start = scIn.find_first_not_of(trimmable);
-	auto end = scIn.find_last_not_of(trimmable);
+	auto start = stringInput.find_first_not_of(trimmable);
+	auto end = stringInput.find_last_not_of(trimmable);
 
 	if (start == end)
-		return scIn;
+		return stringInput;
 
-	return scIn.substr(start, end - start + 1);
+	return stringInput.substr(start, end - start + 1);
 }
 
-inline std::wstring ViewToWString(const std::wstring& sv)
+inline std::wstring ViewToWString(const std::wstring& wstring)
 {
-	return {sv.begin(), sv.end()};
+	return {wstring.begin(), wstring.end()};
 }
 
-inline std::string ViewToString(const std::string_view& sv)
+inline std::string ViewToString(const std::string_view& stringView)
 {
-	return {sv.begin(), sv.end()};
+	return {stringView.begin(), stringView.end()};
 }
 
-inline std::wstring stows(const std::string& scText)
+inline std::wstring stows(const std::string& text)
 {
-	int iSize = MultiByteToWideChar(CP_ACP, 0, scText.c_str(), -1, 0, 0);
-	wchar_t* wszText = new wchar_t[iSize];
-	MultiByteToWideChar(CP_ACP, 0, scText.c_str(), -1, wszText, iSize);
-	std::wstring wscRet = wszText;
-	delete[] wszText;
+	int size = MultiByteToWideChar(CP_ACP, 0, text.c_str(), -1, 0, 0);
+	wchar_t* wideText = new wchar_t[size];
+	MultiByteToWideChar(CP_ACP, 0, text.c_str(), -1, wideText, size);
+	std::wstring wscRet = wideText;
+	delete[] wideText;
 	return wscRet;
 }
 
@@ -265,7 +263,7 @@ inline std::string wstos(const std::wstring& text)
 }
 
 template<typename TStr>
-auto strswa(TStr str)
+auto strswa(TStr str) requires StringRestriction<TStr>
 {
 	if constexpr (std::is_same_v<TStr, std::string>)
 	{
@@ -276,4 +274,3 @@ auto strswa(TStr str)
 		return wstos(str);
 	}
 }
-

--- a/include/Tools/Utils.hpp
+++ b/include/Tools/Utils.hpp
@@ -108,7 +108,8 @@ inline std::wstring XMLText(const std::wstring& text)
 }
 
 template<typename TStr, typename TChar>
-inline TStr GetParam(const TStr& line, TChar splitChar, uint pos) requires StringRestriction<TStr>
+inline TStr GetParam(const TStr& line, TChar splitChar, uint pos)
+    requires StringRestriction<TStr>
 {
 	uint i, j;
 
@@ -131,7 +132,8 @@ inline TStr GetParam(const TStr& line, TChar splitChar, uint pos) requires Strin
 }
 
 template<typename TString, typename TChar>
-TString GetParamToEnd(const TString& line, TChar splitChar, uint pos) requires StringRestriction<TString>
+TString GetParamToEnd(const TString& line, TChar splitChar, uint pos)
+    requires StringRestriction<TString>
 {
 	for (uint i = 0, j = 0; (i <= pos) && (j < line.length()); j++)
 	{
@@ -152,7 +154,8 @@ TString GetParamToEnd(const TString& line, TChar splitChar, uint pos) requires S
 }
 
 template<typename TString, typename TTStr, typename TTTStr>
-TString ReplaceStr(const TString& source, const TTStr& searchForRaw, const TTTStr& replaceWithRaw) requires StringRestriction<TString>
+TString ReplaceStr(const TString& source, const TTStr& searchForRaw, const TTTStr& replaceWithRaw)
+    requires StringRestriction<TString>
 {
 	const TString searchFor = searchForRaw;
 	const TString replaceWith = replaceWithRaw;
@@ -210,7 +213,8 @@ inline std::string ToLower(std::string string)
 Remove leading and trailing spaces from the std::string  ~FlakCommon by Motah.
 */
 template<typename Str>
-Str Trim(const Str& stringInput) requires StringRestriction <Str>
+Str Trim(const Str& stringInput)
+    requires StringRestriction<Str>
 {
 	if (stringInput.empty())
 		return stringInput;
@@ -263,7 +267,8 @@ inline std::string wstos(const std::wstring& text)
 }
 
 template<typename TStr>
-auto strswa(TStr str) requires StringRestriction<TStr>
+auto strswa(TStr str)
+    requires StringRestriction<TStr>
 {
 	if constexpr (std::is_same_v<TStr, std::string>)
 	{

--- a/plugins/cash_manager/Main.cpp
+++ b/plugins/cash_manager/Main.cpp
@@ -426,7 +426,8 @@ namespace Plugins::CashManager
 
 	const std::vector commands = {
 	    {CreateUserCommand(L"/bank", L"", UserCommandHandler, L"A series of commands for storing money that can be shared among multiple characters. \n"
-		"Laz is a gay.")}};
+		"New Line Test \n."
+		"New Line Test2 \n")}};
 
 	BankCode IpcConsumeBankCash(const CAccount* account, uint cashAmount, const std::string& transactionSource)
 	{

--- a/plugins/cash_manager/Main.cpp
+++ b/plugins/cash_manager/Main.cpp
@@ -88,7 +88,7 @@ namespace Plugins::CashManager
 
 		if (bank.cash < withdrawal)
 		{
-			PrintUserCmdText(client, std::format(L"Error: Not enough credits, this bank only has {}", bank.cash));
+			PrintUserCmdText(client, std::format(L"Error: Not enough credits, this bank only has {} credits", bank.cash));
 			return;
 		}
 
@@ -276,8 +276,7 @@ namespace Plugins::CashManager
 			return;
 		}
 
-		if (const auto &blockedSystems = global->config->blockedSystemsHashed;
-		    std::ranges::find(blockedSystems, currentSystem.value()) != blockedSystems.end())
+		if (const auto& blockedSystems = global->config->blockedSystemsHashed; std::ranges::find(blockedSystems, currentSystem.value()) != blockedSystems.end())
 		{
 			PrintUserCmdText(client, L"Error: You are in a blocked system, you are unable to access the bank.");
 			return;
@@ -303,8 +302,9 @@ namespace Plugins::CashManager
 			}
 
 			PrintUserCmdText(client, L"This will generate a new password and the previous will be invalid");
-			PrintUserCmdText(client, std::format(L"Your currently set password is {} if you are sure you want to regenerate your password type \"/bank password confirm\". ",
-			    bank.bankPassword));
+			PrintUserCmdText(client,
+			    std::format(L"Your currently set password is {} if you are sure you want to regenerate your password type \"/bank password confirm\". ",
+			        bank.bankPassword));
 		}
 		else if (cmd == L"identifier")
 		{
@@ -356,8 +356,7 @@ namespace Plugins::CashManager
 		{
 			const auto bank = Sql::GetOrCreateBank(acc);
 
-			if (const auto list = GetParam(param, ' ', 1); 
-				list == L"list")
+			if (const auto list = GetParam(param, ' ', 1); list == L"list")
 			{
 				int totalTransactions = Sql::CountTransactions(bank);
 				const auto page = ToInt(GetParam(param, ' ', 2));
@@ -379,8 +378,7 @@ namespace Plugins::CashManager
 				}
 
 				uint i = page * TransactionsPerPage;
-				for (const auto transactions = Sql::ListTransactions(bank, TransactionsPerPage, i); 
-					const auto& transaction : transactions)
+				for (const auto transactions = Sql::ListTransactions(bank, TransactionsPerPage, i); const auto& transaction : transactions)
 				{
 					PrintUserCmdText(client, std::format(L"%{}.) {} {}", i, transaction.accessor, transaction.amount));
 					i++;
@@ -425,9 +423,7 @@ namespace Plugins::CashManager
 	}
 
 	const std::vector commands = {
-	    {CreateUserCommand(L"/bank", L"", UserCommandHandler, L"A series of commands for storing money that can be shared among multiple characters. \n"
-		"New Line Test \n."
-		"New Line Test2 \n")}};
+	    {CreateUserCommand(L"/bank", L"", UserCommandHandler, L"A series of commands for storing money that can be shared among multiple characters. Type /bank in order to see commands and usage")}};
 
 	BankCode IpcConsumeBankCash(const CAccount* account, uint cashAmount, const std::string& transactionSource)
 	{

--- a/plugins/cash_manager/Main.cpp
+++ b/plugins/cash_manager/Main.cpp
@@ -88,7 +88,7 @@ namespace Plugins::CashManager
 
 		if (bank.cash < withdrawal)
 		{
-			PrintUserCmdText(client, std::format(L"Error: Not enough credits, this bank only has %u", bank.cash));
+			PrintUserCmdText(client, std::format(L"Error: Not enough credits, this bank only has {}", bank.cash));
 			return;
 		}
 
@@ -425,7 +425,8 @@ namespace Plugins::CashManager
 	}
 
 	const std::vector commands = {
-	    {CreateUserCommand(L"/bank", L"", UserCommandHandler, L"A series of commands for storing money that can be shared among multiple characters.")}};
+	    {CreateUserCommand(L"/bank", L"", UserCommandHandler, L"A series of commands for storing money that can be shared among multiple characters. \n"
+		"Laz is a gay.")}};
 
 	BankCode IpcConsumeBankCash(const CAccount* account, uint cashAmount, const std::string& transactionSource)
 	{

--- a/project/FLHook.vcxproj
+++ b/project/FLHook.vcxproj
@@ -233,6 +233,7 @@ setx FLHOOK_SDK_PATH "$(SolutionDir)..\FLHookSDK\\"</Command>
     <ClInclude Include="..\include\Features\Mail.hpp" />
     <ClInclude Include="..\include\FLHook.hpp" />
     <ClInclude Include="..\include\plugin.h" />
+    <ClInclude Include="..\include\Tools\Concepts.hpp" />
     <ClInclude Include="..\include\Tools\Constexpr.hpp" />
     <ClInclude Include="..\include\Tools\Deps.hpp" />
     <ClInclude Include="..\include\Tools\Enums.hpp" />

--- a/project/FLHook.vcxproj.filters
+++ b/project/FLHook.vcxproj.filters
@@ -186,5 +186,8 @@
     <ClInclude Include="..\include\Features\Mail.hpp">
       <Filter>sdk\Features</Filter>
     </ClInclude>
+    <ClInclude Include="..\include\Tools\Concepts.hpp">
+      <Filter>sdk\Tools</Filter>
+    </ClInclude>
   </ItemGroup>
 </Project>

--- a/source/Features/UserCommands.cpp
+++ b/source/Features/UserCommands.cpp
@@ -21,7 +21,8 @@
 
 void PrintUserCmdText(ClientId client, const std::wstring& text)
 {
-	std::wstring xml = L"<TRA data=\"" + FLHookConfig::i()->msgStyle.userCmdStyle + L"\" mask=\"-1\"/><TEXT>" + XMLText(text) + L"</TEXT>";
+	std::wstring xml = std::format(L"<TRA data=\"{}\" mask=\"-1\"/><TEXT>{}</TEXT>", FLHookConfig::i()->msgStyle.userCmdStyle, XMLText(text));
+	ReplaceStr(xml, L"\n", L"</TEXT></PARA><TEXT>");
 	Hk::Message::FMsg(client, xml);
 }
 


### PR DESCRIPTION
Fixed the issue in which %u was being use instead {} in a format string. Added placeholder text for "/help cash_manager bank" to prompt the user to use /bank to get list of commands. 

Added concept that requires the string templates in utils.hpp to be only be usable as a type of std::string or std::wstring. Initial changes to make printusercmd to be able to print multiple messages using  "\n" .