### PR TITLE
Add split string function

### DIFF
--- a/include/Tools/Utils.hpp
+++ b/include/Tools/Utils.hpp
@@ -153,6 +153,34 @@ TString GetParamToEnd(const TString& line, TChar splitChar, uint pos)
 	return TString();
 }
 
+template<typename TString>
+auto Split(const TString& input, const TString& splitCharacter)
+    requires StringRestriction<TString>
+{
+	auto inputCopy = input;
+	size_t pos = 0;
+	std::vector<TString> tokens;
+	while ((pos = inputCopy.find(splitCharacter)) != TString::npos)
+	{
+		TString token = inputCopy.substr(0, pos);
+		tokens.emplace_back(token);
+		inputCopy.erase(0, pos + splitCharacter.length());
+	}
+
+	if (!inputCopy.empty() && inputCopy.size() != input.size())
+	{
+		tokens.emplace_back(inputCopy);
+	}
+	return tokens;
+}
+
+template<typename TString, typename TChar>
+auto Split(const TString& input, const TChar& splitCharacter)
+    requires StringRestriction<TString>
+{
+	return Split(input, TString(1, splitCharacter));
+}
+
 template<typename TString, typename TTStr, typename TTTStr>
 TString ReplaceStr(const TString& source, const TTStr& searchForRaw, const TTTStr& replaceWithRaw)
     requires StringRestriction<TString>


### PR DESCRIPTION
Basic function for splitting string based on delimiter. Long term for performance reasons we should aim to phase out GetParam being used everywhere and instead call this and grab by index. GetParam is inefficient as it will reparse the string every time splitting based on the specified character. 